### PR TITLE
[CVE-2017-8270] BACKPORT (from): qcacld-2.0: Race condition while using pkt log buffer

### DIFF
--- a/core/utils/pktlog/linux_ac.c
+++ b/core/utils/pktlog/linux_ac.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2016 The Linux Foundation. All rights reserved.
+ * Copyright (c) 2012-2017 The Linux Foundation. All rights reserved.
  *
  * Previously licensed under the ISC license by Qualcomm Atheros, Inc.
  *
@@ -518,12 +518,14 @@ static void pktlog_detach(struct hif_opaque_softc *scn)
 	pl_info = pl_dev->pl_info;
 	remove_proc_entry(WLANDEV_BASENAME, g_pktlog_pde);
 	pktlog_sysctl_unregister(pl_dev);
-	pktlog_cleanup(pl_info);
 
+	spin_lock_bh(&pl_info->log_lock);
 	if (pl_info->buf) {
 		pktlog_release_buf(scn);
 		pl_dev->tgt_pktlog_alloced = false;
 	}
+	spin_unlock_bh(&pl_info->log_lock);
+	pktlog_cleanup(pl_info);
 
 	if (pl_dev) {
 		kfree(pl_info);
@@ -572,12 +574,17 @@ pktlog_read_proc_entry(char *buf, size_t nbytes, loff_t *ppos,
 	int rem_len;
 	int start_offset, end_offset;
 	int fold_offset, ppos_data, cur_rd_offset, cur_wr_offset;
-	struct ath_pktlog_buf *log_buf = pl_info->buf;
+	struct ath_pktlog_buf *log_buf;
+
+	spin_lock_bh(&pl_info->log_lock);
+	log_buf = pl_info->buf;
+
 	*read_complete = false;
 
 	if (log_buf == NULL) {
 		*read_complete = true;
 		return 0;
+		spin_unlock_bh(&pl_info->log_lock);
 	}
 
 	if (*ppos == 0 && pl_info->log_state) {
@@ -679,7 +686,6 @@ rd_done:
 	*ppos += ret_val;
 
 	if (ret_val == 0) {
-		PKTLOG_LOCK(pl_info);
 		/* Write pointer might have been updated during the read.
 		 * So, if some data is written into, lets not reset the pointers
 		 * We can continue to read from the offset position
@@ -693,9 +699,9 @@ rd_done:
 			pl_info->buf->offset = PKTLOG_READ_OFFSET;
 			*read_complete = true;
 		}
-		PKTLOG_UNLOCK(pl_info);
 	}
 
+	spin_unlock_bh(&pl_info->log_lock);
 	return ret_val;
 }
 
@@ -715,10 +721,13 @@ pktlog_read(struct file *file, char *buf, size_t nbytes, loff_t *ppos)
 	if (!pl_info)
 		return 0;
 
+	spin_lock_bh(&pl_info->log_lock);
 	log_buf = pl_info->buf;
 
-	if (log_buf == NULL)
+	if (log_buf == NULL) {
+		spin_unlock_bh(&pl_info->log_lock);
 		return 0;
+	}
 
 	if (pl_info->log_state) {
 		/* Read is not allowed when write is going on
@@ -741,11 +750,13 @@ pktlog_read(struct file *file, char *buf, size_t nbytes, loff_t *ppos)
 
 	if (*ppos < bufhdr_size) {
 		count = QDF_MIN((bufhdr_size - *ppos), rem_len);
+		spin_unlock_bh(&pl_info->log_lock);
 		if (copy_to_user(buf, ((char *)&log_buf->bufhdr) + *ppos,
 				 count))
 			return -EFAULT;
 		rem_len -= count;
 		ret_val += count;
+		spin_lock_bh(&pl_info->log_lock);
 	}
 
 	start_offset = log_buf->rd_offset;
@@ -787,19 +798,23 @@ pktlog_read(struct file *file, char *buf, size_t nbytes, loff_t *ppos)
 			goto rd_done;
 
 		count = QDF_MIN(rem_len, (end_offset - ppos_data + 1));
+		spin_unlock_bh(&pl_info->log_lock);
 		if (copy_to_user(buf + ret_val,
 				 log_buf->log_data + ppos_data, count))
 			return -EFAULT;
 		ret_val += count;
 		rem_len -= count;
+		spin_lock_bh(&pl_info->log_lock);
 	} else {
 		if (ppos_data <= fold_offset) {
 			count = QDF_MIN(rem_len, (fold_offset - ppos_data + 1));
+			spin_unlock_bh(&pl_info->log_lock);
 			if (copy_to_user(buf + ret_val,
 					 log_buf->log_data + ppos_data, count))
 				return -EFAULT;
 			ret_val += count;
 			rem_len -= count;
+			spin_lock_bh(&pl_info->log_lock);
 		}
 
 		if (rem_len == 0)
@@ -811,11 +826,13 @@ pktlog_read(struct file *file, char *buf, size_t nbytes, loff_t *ppos)
 
 		if (ppos_data <= end_offset) {
 			count = QDF_MIN(rem_len, (end_offset - ppos_data + 1));
+			spin_unlock_bh(&pl_info->log_lock);
 			if (copy_to_user(buf + ret_val,
 					 log_buf->log_data + ppos_data, count))
 				return -EFAULT;
 			ret_val += count;
 			rem_len -= count;
+			spin_lock_bh(&pl_info->log_lock);
 		}
 	}
 
@@ -826,6 +843,7 @@ rd_done:
 	}
 	*ppos += ret_val;
 
+	spin_unlock_bh(&pl_info->log_lock);
 	return ret_val;
 }
 

--- a/core/utils/pktlog/pktlog_ac.c
+++ b/core/utils/pktlog/pktlog_ac.c
@@ -424,6 +424,7 @@ int pktlog_enable(struct hif_opaque_softc *scn, int32_t log_state,
 
 		}
 
+		spin_lock_bh(&pl_info->log_lock);
 		pl_info->buf->bufhdr.version = CUR_PKTLOG_VER;
 		pl_info->buf->bufhdr.magic_num = PKTLOG_MAGIC_NUM;
 		pl_info->buf->wr_offset = 0;
@@ -432,6 +433,7 @@ int pktlog_enable(struct hif_opaque_softc *scn, int32_t log_state,
 		pl_info->buf->bytes_written = 0;
 		pl_info->buf->msg_index = 1;
 		pl_info->buf->offset = PKTLOG_READ_OFFSET;
+		spin_unlock_bh(&pl_info->log_lock);
 
 		pl_info->start_time_thruput = os_get_timestamp();
 		pl_info->start_time_per = pl_info->start_time_thruput;
@@ -496,6 +498,7 @@ int pktlog_setsize(struct hif_opaque_softc *scn, int32_t size)
 		return -EINVAL;
 	}
 
+	spin_lock_bh(&pl_info->log_lock);
 	if (pl_info->buf != NULL) {
 		if (pl_dev->is_pktlog_cb_subscribed &&
 			wdi_pktlog_unsubscribe(pdev_txrx_handle,
@@ -512,6 +515,7 @@ int pktlog_setsize(struct hif_opaque_softc *scn, int32_t size)
 		qdf_print("%s: New Pktlog Buff Size is %d\n", __func__, size);
 		pl_info->buf_size = size;
 	}
+	spin_unlock_bh(&pl_info->log_lock);
 
 	return 0;
 }


### PR DESCRIPTION
There can be a race condition if two different threads use the
pkt log buffer at the same time. This issue can lead to Use-After-Free
of the packet log buffer.

To address this issue, protect the pktlog buffer access using spinlock.

Bug: 35468665
Change-Id: I8098bb78a8e2462e109cee3407683c669f151fd5
CRs-Fixed:  2021363