### PR TITLE
Fix issues that trigger compiler warnings with gcc 7.2.1

### DIFF
--- a/core/bmi/src/ol_fw.c
+++ b/core/bmi/src/ol_fw.c
@@ -1339,10 +1339,10 @@ QDF_STATUS ol_download_firmware(struct ol_context *ol_ctx)
 		case QCA9379_REV1_VERSION:
 		case AR6320_REV4_VERSION:
 		case AR6320_DEV_VERSION:
-		if (hif_get_bus_type(scn) == QDF_BUS_TYPE_SDIO)
-			param = 19;
-		else
-			param = 6;
+			if (hif_get_bus_type(scn) == QDF_BUS_TYPE_SDIO)
+				param = 19;
+			else
+				param = 6;
 
 			break;
 		default:

--- a/core/dp/txrx/ol_txrx.c
+++ b/core/dp/txrx/ol_txrx.c
@@ -4912,12 +4912,12 @@ bool ol_txrx_set_ocb_def_tx_param(ol_txrx_vdev_handle vdev,
 	struct ocb_tx_ctrl_hdr_t *def_tx_param =
 		(struct ocb_tx_ctrl_hdr_t *)_def_tx_param;
 
-		if (def_tx_param) {
-			/*
-			* Default TX parameters are provided.
-			* Validate the contents and
-			* save them in the vdev.
-			*/
+	if (def_tx_param) {
+		/*
+		* Default TX parameters are provided.
+		* Validate the contents and
+		* save them in the vdev.
+		*/
 		if (def_tx_param_size != sizeof(struct ocb_tx_ctrl_hdr_t)) {
 			QDF_TRACE(QDF_MODULE_ID_TXRX, QDF_TRACE_LEVEL_ERROR,
 			"%sInvalid size of OCB default TX params", __func__);
@@ -4963,9 +4963,9 @@ bool ol_txrx_set_ocb_def_tx_param(ol_txrx_vdev_handle vdev,
 		if (vdev->ocb_def_tx_param == NULL)
 			vdev->ocb_def_tx_param =
 				qdf_mem_malloc(sizeof(*vdev->ocb_def_tx_param));
-			qdf_mem_copy(vdev->ocb_def_tx_param, def_tx_param,
-				sizeof(*vdev->ocb_def_tx_param));
-		} else {
+		qdf_mem_copy(vdev->ocb_def_tx_param, def_tx_param,
+			sizeof(*vdev->ocb_def_tx_param));
+	} else {
 		/*
 		* Default TX parameters are not provided.
 		* Delete the old defaults.

--- a/core/hdd/inc/wlan_hdd_cfg.h
+++ b/core/hdd/inc/wlan_hdd_cfg.h
@@ -10316,7 +10316,7 @@ struct hdd_config {
 	uint32_t ibssPs1RxChainInAtimEnable;
 
 	bool enable_ip_tcp_udp_checksum_offload;
-	bool enablePowersaveOffload;
+	enum powersave_mode enablePowersaveOffload;
 	bool enablefwprint;
 	uint8_t enable_fw_log;
 	uint8_t fVhtAmpduLenExponent;

--- a/core/hdd/src/wlan_hdd_assoc.c
+++ b/core/hdd/src/wlan_hdd_assoc.c
@@ -493,11 +493,11 @@ static void hdd_copy_ht_caps(hdd_station_ctx_t *hdd_sta_ctx,
 	for (i = 0; i < IEEE80211_HT_MCS_MASK_LEN; ++i)
 		hdd_ht_cap->mcs.rx_mask[i] =
 			roam_ht_cap->supportedMCSSet[i];
-		hdd_ht_cap->mcs.rx_highest =
-			((short) (roam_ht_cap->supportedMCSSet[11]) << 8) |
-			((short) (roam_ht_cap->supportedMCSSet[10]));
-		hdd_ht_cap->mcs.tx_params =
-			roam_ht_cap->supportedMCSSet[12];
+	hdd_ht_cap->mcs.rx_highest =
+		((short) (roam_ht_cap->supportedMCSSet[11]) << 8) |
+		((short) (roam_ht_cap->supportedMCSSet[10]));
+	hdd_ht_cap->mcs.tx_params =
+		roam_ht_cap->supportedMCSSet[12];
 }
 
 #define VHT_CAP_MAX_MPDU_LENGTH_MASK 0x00000003
@@ -537,7 +537,7 @@ static void hdd_copy_vht_caps(hdd_station_ctx_t *hdd_sta_ctx,
 	temp_vht_cap = roam_vht_cap->supportedChannelWidthSet &
 		(IEEE80211_VHT_CAP_SUPP_CHAN_WIDTH_MASK >>
 			VHT_CAP_SUPP_CHAN_WIDTH_MASK_SHIFT);
-	if (temp_vht_cap)
+	if (temp_vht_cap) {
 		if (roam_vht_cap->supportedChannelWidthSet &
 		    (IEEE80211_VHT_CAP_SUPP_CHAN_WIDTH_160MHZ >>
 			VHT_CAP_SUPP_CHAN_WIDTH_MASK_SHIFT))
@@ -550,6 +550,7 @@ static void hdd_copy_vht_caps(hdd_station_ctx_t *hdd_sta_ctx,
 			hdd_vht_cap->vht_cap_info |=
 			temp_vht_cap <<
 			IEEE80211_VHT_CAP_SUPP_CHAN_WIDTH_160_80PLUS80MHZ;
+	}
 	if (roam_vht_cap->ldpcCodingCap)
 		hdd_vht_cap->vht_cap_info |= IEEE80211_VHT_CAP_RXLDPC;
 	if (roam_vht_cap->shortGI80MHz)

--- a/core/hdd/src/wlan_hdd_main.c
+++ b/core/hdd/src/wlan_hdd_main.c
@@ -8563,8 +8563,8 @@ static void hdd_state_info_dump(char **buf_ptr, uint16_t *size)
 		if (adapter->dev)
 			len += scnprintf(buf + len, *size - len,
 				"\n device name: %s", adapter->dev->name);
-			len += scnprintf(buf + len, *size - len,
-				"\n device_mode: %d", adapter->device_mode);
+		len += scnprintf(buf + len, *size - len,
+			"\n device_mode: %d", adapter->device_mode);
 		switch (adapter->device_mode) {
 		case QDF_STA_MODE:
 		case QDF_P2P_CLIENT_MODE:

--- a/core/hdd/src/wlan_hdd_napi.c
+++ b/core/hdd/src/wlan_hdd_napi.c
@@ -382,8 +382,8 @@ int hdd_napi_apply_throughput_policy(struct hdd_context_s *hddctx,
 	if (req_state != napid->napi_mode)
 		/* [re]set the floor frequency of high cluster */
 		rc = hdd_napi_perfd_cpufreq(req_state);
-		/* blacklist/boost_mode on/off */
-		rc = hdd_napi_event(NAPI_EVT_TPUT_STATE, (void *)req_state);
+	/* blacklist/boost_mode on/off */
+	rc = hdd_napi_event(NAPI_EVT_TPUT_STATE, (void *)req_state);
 	return rc;
 }
 

--- a/core/mac/src/pe/lim/lim_process_sme_req_messages.c
+++ b/core/mac/src/pe/lim/lim_process_sme_req_messages.c
@@ -2841,23 +2841,23 @@ static void __lim_process_sme_deauth_req(tpAniSirGlobal mac_ctx,
 				ret_code = eSIR_SME_STA_NOT_AUTHENTICATED;
 				deauth_trigger = eLIM_HOST_DEAUTH;
 
-			/*
-			 * here we received deauth request from AP so sme state
-			 * is eLIM_SME_WT_DEAUTH_STATE.if we have ISSUED
-			 * delSta then mlm state should be
-			 * eLIM_MLM_WT_DEL_STA_RSP_STATE and ifwe got delBSS
-			 * rsp then mlm state should be eLIM_MLM_IDLE_STATE
-			 * so the below condition captures the state where
-			 * delSta not done and firmware still in
-			 * connected state.
-			 */
-			if (session_entry->limSmeState ==
-					eLIM_SME_WT_DEAUTH_STATE &&
-					session_entry->limMlmState !=
-					eLIM_MLM_IDLE_STATE &&
-					session_entry->limMlmState !=
-					eLIM_MLM_WT_DEL_STA_RSP_STATE)
-				ret_code = eSIR_SME_DEAUTH_STATUS;
+				/*
+				 * here we received deauth request from AP so sme state
+				 * is eLIM_SME_WT_DEAUTH_STATE.if we have ISSUED
+				 * delSta then mlm state should be
+				 * eLIM_MLM_WT_DEL_STA_RSP_STATE and ifwe got delBSS
+				 * rsp then mlm state should be eLIM_MLM_IDLE_STATE
+				 * so the below condition captures the state where
+				 * delSta not done and firmware still in
+				 * connected state.
+				 */
+				if (session_entry->limSmeState ==
+						eLIM_SME_WT_DEAUTH_STATE &&
+						session_entry->limMlmState !=
+						eLIM_MLM_IDLE_STATE &&
+						session_entry->limMlmState !=
+						eLIM_MLM_WT_DEL_STA_RSP_STATE)
+					ret_code = eSIR_SME_DEAUTH_STATUS;
 				goto send_deauth;
 			}
 			return;

--- a/core/mac/src/pe/lim/lim_process_tdls.c
+++ b/core/mac/src/pe/lim/lim_process_tdls.c
@@ -1730,7 +1730,7 @@ static tSirRetStatus lim_send_tdls_setup_rsp_frame(tpAniSirGlobal pMac,
 		    eSIR_SUCCESS)
 			lim_log(pMac, LOGE,
 				FL("could not retrieve Max SP Length"));
-			tdlsSetupRsp.WMMInfoStation.max_sp_length = (uint8_t) val;
+		tdlsSetupRsp.WMMInfoStation.max_sp_length = (uint8_t) val;
 		tdlsSetupRsp.WMMInfoStation.present = 1;
 	} else {
 		/*

--- a/core/mac/src/pe/lim/lim_prop_exts_utils.c
+++ b/core/mac/src/pe/lim/lim_prop_exts_utils.c
@@ -75,8 +75,8 @@ static void get_local_power_constraint_probe_response(
 	if (beacon_struct->eseTxPwr.present)
 		*local_constraint =
 			beacon_struct->eseTxPwr.power_limit;
-		session->is_ese_version_ie_present =
-			beacon_struct->is_ese_ver_ie_present;
+	session->is_ese_version_ie_present =
+		beacon_struct->is_ese_ver_ie_present;
 }
 #else
 static void get_local_power_constraint_probe_response(

--- a/core/mac/src/pe/lim/lim_utils.c
+++ b/core/mac/src/pe/lim/lim_utils.c
@@ -4075,16 +4075,16 @@ static void lim_handle_ht20coexist_ht20protection(tpAniSirGlobal mac_ctx,
 					session_entry->htOperMode =
 					eSIR_HT_OP_MODE_NO_LEGACY_20MHZ_HT;
 
-					lim_enable_ht_rifs_protection(mac_ctx,
-						false, overlap, beaconparams,
-						session_entry);
-					lim_enable_ht_obss_protection(mac_ctx,
-						false, overlap, beaconparams,
-						session_entry);
-				} else {
-					session_entry->htOperMode =
-						eSIR_HT_OP_MODE_PURE;
-				}
+				lim_enable_ht_rifs_protection(mac_ctx,
+					false, overlap, beaconparams,
+					session_entry);
+				lim_enable_ht_obss_protection(mac_ctx,
+					false, overlap, beaconparams,
+					session_entry);
+			} else {
+				session_entry->htOperMode =
+					eSIR_HT_OP_MODE_PURE;
+			}
 		}
 	} else if (LIM_IS_AP_ROLE(session_entry) && !overlap) {
 		/* Disable protection from 11G stations. */

--- a/core/mac/src/sys/legacy/src/utils/src/parser_api.c
+++ b/core/mac/src/sys/legacy/src/utils/src/parser_api.c
@@ -1538,7 +1538,7 @@ populate_dot11f_qos_caps_station(tpAniSirGlobal pMac, tpPESession pe_session,
 		lim_log(pMac, LOGE,
 			FL("could not retrieve Max SP Length"));
 
-		pDot11f->more_data_ack = 0;
+	pDot11f->more_data_ack = 0;
 	pDot11f->max_sp_length = (uint8_t) val;
 	pDot11f->qack = 0;
 
@@ -2046,7 +2046,7 @@ void populate_dot11f_wmm_info_station_per_session(tpAniSirGlobal pMac,
 		lim_log(pMac, LOGE,
 			FL("could not retrieve Max SP Length"));
 
-		pInfo->max_sp_length = (uint8_t) val;
+	pInfo->max_sp_length = (uint8_t) val;
 	pInfo->present = 1;
 }
 

--- a/core/utils/fwlog/dbglog_host.c
+++ b/core/utils/fwlog/dbglog_host.c
@@ -1355,13 +1355,6 @@ int dbglog_report_enable(wmi_unified_t wmi_handle, bool isenable)
 {
 	int bitmap[2] = { 0 };
 
-	if (isenable > true) {
-		AR_DEBUG_PRINTF(ATH_DEBUG_ERR,
-				("dbglog_report_enable:Invalid value %d\n",
-				 isenable));
-		return -EINVAL;
-	}
-
 	if (isenable) {
 		/* set the vap enable bitmap */
 		dbglog_set_vap_enable_bitmap(wmi_handle, 0xFFFF);


### PR DESCRIPTION
Small issues: Misleading indentation looking like an if statement
ends in the wrong place, checking a variable of type bool for
values > true (impossible), etc.

The only change in here that has any effect other than silencing
warnings and reducing the headaches of someone trying to read
the code is changing the type of enablePowersaveOffload in
struct hdd_config: According to the code in wlan_hdd_main.c, it is
clearly meant to take 3 different values (0/nodeepsleep/deepsleep), so
it can't be bool.
Another option may be to keep it as bool and unify 0 and nodeepsleep
into false and changing deepsleep to true

Signed-off-by: Bernhard Rosenkränzer <bero@lindev.ch>