### PR TITLE
[LE.UM.2.3.2.r1.4] Revert "Revert "qcacld-3.0: Add wait during module_init for static driver""

### DIFF
--- a/core/hdd/src/wlan_hdd_main.c
+++ b/core/hdd/src/wlan_hdd_main.c
@@ -12298,6 +12298,28 @@ static void wlan_hdd_state_ctrl_param_destroy(void)
 	pr_info("Device node unregistered");
 }
 
+#ifndef MODULE
+static int hdd_wait_for_probe_complete(void)
+{
+	unsigned long rc;
+
+	rc = wait_for_completion_timeout(&wlan_start_comp,
+				msecs_to_jiffies(HDD_WLAN_START_WAIT_TIME));
+
+	if (!rc) {
+		hdd_alert("Timed-out waiting for Probe to complete");
+		return -ETIMEDOUT;
+	}
+
+	return 0;
+}
+#else
+static int hdd_wait_for_probe_complete(void)
+{
+	return 0;
+}
+#endif
+
 /**
  * __hdd_module_init - Module init helper
  *
@@ -12330,6 +12352,12 @@ static int __hdd_module_init(void)
 	if (ret) {
 		pr_err("%s: driver load failure, err %d\n", WLAN_MODULE_NAME,
 			ret);
+		goto out;
+	}
+
+	if (hdd_wait_for_probe_complete()) {
+		pr_err("%s: probe of the driver failed!", __func__);
+		wlan_hdd_unregister_driver();
 		goto out;
 	}
 
@@ -12399,6 +12427,7 @@ static ssize_t wlan_boot_cb(struct kobject *kobj,
 		return -EALREADY;
 	}
 
+	init_completion(&wlan_start_comp);
 	if (__hdd_module_init()) {
 		pr_err("%s: wlan driver initialization failed\n", __func__);
 		return -EIO;
@@ -12500,7 +12529,6 @@ static int wlan_deinit_sysfs(void)
 	hdd_sysfs_cleanup();
 	return 0;
 }
-
 #endif /* MODULE */
 
 #ifdef MODULE


### PR DESCRIPTION
This allows the WiFi to reconnect automatically after boot/reboot.

