### PR TITLE
[QCACLD] [7.1.r1] hdd: wlan_hdd_main: Do not return error codes if wlan already booted

### DIFF
--- a/core/hdd/src/wlan_hdd_main.c
+++ b/core/hdd/src/wlan_hdd_main.c
@@ -13357,7 +13357,8 @@ static ssize_t wlan_boot_cb(struct kobject *kobj,
 
 	if (wlan_loader->loaded_state) {
 		hdd_fln("wlan driver already initialized");
-		return -EALREADY;
+		return count;
+		//return -EALREADY;
 	}
 
 	if (hdd_driver_load())


### PR DESCRIPTION
If the WLAN is already booted up and we return an error code here,
in the event of a restart of the Android WiFi HAL, it will try to
boot the wlan again and fail miserably, due to this function
returning an error: at this point, the HAL will get killed over
and over, locking up the userspace boot process forever.

WLAN already booted is not an error, especially when this driver is
compiled in, so return cleanly in order to solve the userspace bug.