### PR TITLE
[QCACLD3.0] qcacld-3.0: Properly handle IPA uC ready notification

### DIFF
--- a/components/ipa/core/src/wlan_ipa_core.c
+++ b/components/ipa/core/src/wlan_ipa_core.c
@@ -115,11 +115,11 @@ static void wlan_ipa_uc_loaded_uc_cb(void *priv_ctxt)
 	}
 
 	ipa_ctx = priv_ctxt;
-	ipa_ctx->uc_loaded = true;
 
 	uc_op_work = &ipa_ctx->uc_op_work[WLAN_IPA_UC_OPCODE_UC_READY];
 	if (!list_empty(&uc_op_work->work.work.entry)) {
 		/* uc_op_work is not initialized yet */
+		ipa_ctx->uc_loaded = true;
 		return;
 	}
 
@@ -2574,15 +2574,11 @@ static void wlan_ipa_uc_loaded_handler(struct wlan_ipa_priv *ipa_ctx)
 
 	ipa_info("UC READY");
 
-	if (!qdf_dev) {
-		ipa_err("qdf device is NULL!");
-		return;
-	}
-
 	if (true == ipa_ctx->uc_loaded) {
 		ipa_info("UC already loaded");
 		return;
 	}
+	ipa_ctx->uc_loaded = true;
 
 	if (!qdf_dev) {
 		ipa_err("qdf_dev is null");


### PR DESCRIPTION
When doing IPA initialization, WLAN driver registers a
notification callback for IPA uC ready. In the callback,
we directly set uc_loaded to true before scheduling a work
task to connect WLAN IPA pipes. However issue is that in
the work handler, uc_loaded is checked and if it is true,
we return without connecting WLAN IPA pipes.

Therefore properly set uc_loaded to true so that WLAN IPA
pipes can be connected correctly.

Change-Id: I27a14e627a1a75836f08dc5dec8c8b1d09725e10
CRs-Fixed: 2537625


------------------------

This fixes a bug happening especially on IPA2 during SSR sequence.