### PR TITLE
[QCACLD] [LA.UM.7.1.r1] Build cleanup and git "error" fixes

### DIFF
--- a/Kbuild
+++ b/Kbuild
@@ -2193,8 +2193,7 @@ CMN_IDS = $(shell cd "$(PWD)/$(WLAN_COMMON_INC)" && \
 		sed -nE 's/^\s*Change-Id: (I[0-f]{10})[0-f]{30}\s*$$/\1/p' | \
 		paste -sd "," -)
 
-TIMESTAMP = $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
-BUILD_TAG = "$(TIMESTAMP); cld:$(CLD_IDS); cmn:$(CMN_IDS);"
+BUILD_TAG = "cld:$(CLD_IDS); cmn:$(CMN_IDS);"
 # It's assumed that BUILD_TAG is used only in wlan_hdd_main.c
 CFLAGS_wlan_hdd_main.o += -DBUILD_TAG=\"$(BUILD_TAG)\"
 endif

--- a/Kbuild
+++ b/Kbuild
@@ -2179,16 +2179,16 @@ endif
 
 # inject some build related information
 ifeq ($(CONFIG_BUILD_TAG), y)
-CLD_CHECKOUT = $(shell cd "$(WLAN_ROOT)" && \
+CLD_CHECKOUT = $(shell cd "$(PWD)/$(WLAN_ROOT)" && \
 	git reflog | grep -vm1 "}: cherry-pick: " | grep -oE ^[0-f]+)
-CLD_IDS = $(shell cd "$(WLAN_ROOT)" && \
+CLD_IDS = $(shell cd "$(PWD)/$(WLAN_ROOT)" && \
 	git log -50 $(CLD_CHECKOUT)~..HEAD | \
 		sed -nE 's/^\s*Change-Id: (I[0-f]{10})[0-f]{30}\s*$$/\1/p' | \
 		paste -sd "," -)
 
-CMN_CHECKOUT = $(shell cd "$(WLAN_COMMON_INC)" && \
+CMN_CHECKOUT = $(shell cd "$(PWD)/$(WLAN_COMMON_INC)" && \
 	git reflog | grep -vm1 "}: cherry-pick: " | grep -oE ^[0-f]+)
-CMN_IDS = $(shell cd "$(WLAN_COMMON_INC)" && \
+CMN_IDS = $(shell cd "$(PWD)/$(WLAN_COMMON_INC)" && \
 	git log -50 $(CMN_CHECKOUT)~..HEAD | \
 		sed -nE 's/^\s*Change-Id: (I[0-f]{10})[0-f]{30}\s*$$/\1/p' | \
 		paste -sd "," -)


### PR DESCRIPTION
As shown and promised _months ago_, packaged in a nice commit this time :wink: 

This cleans up the build, getting rid of `git` path errors because `$(shell)` is started in the `O=` directory rather than the source directory where `Kbuild is evaluated.

Also, drop the timestamp from `BUILD_TAG`: we don't ever look at it and it only causes a ton of files to be recompiled _every time_.