### PR TITLE
[8.1.r1] Port our patches from 7.1

### DIFF
--- a/Kbuild
+++ b/Kbuild
@@ -13,6 +13,10 @@ ifeq ($(KERNEL_BUILD), y)
 	WLAN_ROOT := drivers/staging/wlan-qc/qcacld-3.0
 	WLAN_COMMON_ROOT := ../qca-wifi-host-cmn
 	WLAN_COMMON_INC := $(WLAN_ROOT)/$(WLAN_COMMON_ROOT)
+
+	# Disable debugging by forcing BUILD_VARIANT user if
+	# we are building this outside of Android
+	TARGET_BUILD_VARIANT := user
 endif
 
 WLAN_COMMON_ROOT ?= ../qca-wifi-host-cmn

--- a/Kbuild
+++ b/Kbuild
@@ -2285,16 +2285,16 @@ endif
 
 # inject some build related information
 ifeq ($(CONFIG_BUILD_TAG), y)
-CLD_CHECKOUT = $(shell cd "$(WLAN_ROOT)" && \
+CLD_CHECKOUT = $(shell cd "$(PWD)/$(WLAN_ROOT)" && \
 	git reflog | grep -vm1 "}: cherry-pick: " | grep -oE ^[0-f]+)
-CLD_IDS = $(shell cd "$(WLAN_ROOT)" && \
+CLD_IDS = $(shell cd "$(PWD)/$(WLAN_ROOT)" && \
 	git log -50 $(CLD_CHECKOUT)~..HEAD | \
 		sed -nE 's/^\s*Change-Id: (I[0-f]{10})[0-f]{30}\s*$$/\1/p' | \
 		paste -sd "," -)
 
-CMN_CHECKOUT = $(shell cd "$(WLAN_COMMON_INC)" && \
+CMN_CHECKOUT = $(shell cd "$(PWD)/$(WLAN_COMMON_INC)" && \
 	git reflog | grep -vm1 "}: cherry-pick: " | grep -oE ^[0-f]+)
-CMN_IDS = $(shell cd "$(WLAN_COMMON_INC)" && \
+CMN_IDS = $(shell cd "$(PWD)/$(WLAN_COMMON_INC)" && \
 	git log -50 $(CMN_CHECKOUT)~..HEAD | \
 		sed -nE 's/^\s*Change-Id: (I[0-f]{10})[0-f]{30}\s*$$/\1/p' | \
 		paste -sd "," -)

--- a/Kbuild
+++ b/Kbuild
@@ -2299,8 +2299,7 @@ CMN_IDS = $(shell cd "$(PWD)/$(WLAN_COMMON_INC)" && \
 		sed -nE 's/^\s*Change-Id: (I[0-f]{10})[0-f]{30}\s*$$/\1/p' | \
 		paste -sd "," -)
 
-TIMESTAMP = $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
-BUILD_TAG = "$(TIMESTAMP); cld:$(CLD_IDS); cmn:$(CMN_IDS);"
+BUILD_TAG = "cld:$(CLD_IDS); cmn:$(CMN_IDS);"
 # It's assumed that BUILD_TAG is used only in wlan_hdd_main.c
 CFLAGS_wlan_hdd_main.o += -DBUILD_TAG=\"$(BUILD_TAG)\"
 endif

--- a/Kbuild
+++ b/Kbuild
@@ -10,7 +10,7 @@ ifeq ($(KERNEL_BUILD), y)
 	# These are provided in external module based builds
 	# Need to explicitly define for Kernel-based builds
 	MODNAME := wlan
-	WLAN_ROOT := drivers/staging/qcacld-3.0
+	WLAN_ROOT := drivers/staging/wlan-qc/qcacld-3.0
 	WLAN_COMMON_ROOT := ../qca-wifi-host-cmn
 	WLAN_COMMON_INC := $(WLAN_ROOT)/$(WLAN_COMMON_ROOT)
 endif

--- a/components/ipa/core/src/wlan_ipa_core.c
+++ b/components/ipa/core/src/wlan_ipa_core.c
@@ -115,11 +115,11 @@ static void wlan_ipa_uc_loaded_uc_cb(void *priv_ctxt)
 	}
 
 	ipa_ctx = priv_ctxt;
-	ipa_ctx->uc_loaded = true;
 
 	uc_op_work = &ipa_ctx->uc_op_work[WLAN_IPA_UC_OPCODE_UC_READY];
 	if (!list_empty(&uc_op_work->work.work.entry)) {
 		/* uc_op_work is not initialized yet */
+		ipa_ctx->uc_loaded = true;
 		return;
 	}
 
@@ -2641,15 +2641,11 @@ static void wlan_ipa_uc_loaded_handler(struct wlan_ipa_priv *ipa_ctx)
 
 	ipa_info("UC READY");
 
-	if (!qdf_dev) {
-		ipa_err("qdf device is NULL!");
-		return;
-	}
-
 	if (true == ipa_ctx->uc_loaded) {
 		ipa_info("UC already loaded");
 		return;
 	}
+	ipa_ctx->uc_loaded = true;
 
 	if (!qdf_dev) {
 		ipa_err("qdf_dev is null");

--- a/core/hdd/src/wlan_hdd_main.c
+++ b/core/hdd/src/wlan_hdd_main.c
@@ -14277,7 +14277,8 @@ static ssize_t wlan_boot_cb(struct kobject *kobj,
 
 	if (wlan_loader->loaded_state) {
 		hdd_fln("wlan driver already initialized");
-		return -EALREADY;
+		return count;
+		//return -EALREADY;
 	}
 
 	if (hdd_driver_load())


### PR DESCRIPTION
Requires https://github.com/sonyxperiadev/kernel/pull/2292 instead of reverting pmkid caching.

Tested for months (on the older 8.1-14700 tag as well) on Akatsuki DSDS.

22e3a543ac4e19a8c694fee843238b26de0eacfe may not be necessary - this is a remnant from newer 7.1 tags but hasn't landed (yet?) on 8.1.