### PR TITLE
[QCACLD-3.0] [8.1.r1] Disable debugging and reduce memory footprint

### DIFF
--- a/configs/default_defconfig
+++ b/configs/default_defconfig
@@ -344,7 +344,7 @@ endif
 # Feature flags which are not (currently) configurable via Kconfig
 
 #Whether to build debug version
-BUILD_DEBUG_VERSION := y
+BUILD_DEBUG_VERSION := n
 
 #Enable this flag to build driver in diag version
 BUILD_DIAG_VERSION := y

--- a/configs/default_defconfig
+++ b/configs/default_defconfig
@@ -686,3 +686,10 @@ CONFIG_WLAN_HANG_EVENT := y
 
 # Disable packet logging to stop wasting memory
 CONFIG_SLUB_MEM_OPTIMIZE := y
+
+# Do not even compile-in the debug prints
+CONFIG_WLAN_LOG_DEBUG := n
+CONFIG_FEATURE_TSO_DEBUG := n
+CONFIG_TSO_DEBUG_LOG_ENABLE := n
+CONFIG_WLAN_FEATURE_P2P_DEBUG := n
+CONFIG_ENABLE_MTRACE_LOG := n

--- a/configs/default_defconfig
+++ b/configs/default_defconfig
@@ -683,3 +683,6 @@ CONFIG_WLAN_FEATURE_PKT_CAPTURE := y
 endif
 
 CONFIG_WLAN_HANG_EVENT := y
+
+# Disable packet logging to stop wasting memory
+CONFIG_SLUB_MEM_OPTIMIZE := y

--- a/core/hdd/src/wlan_hdd_assoc.c
+++ b/core/hdd/src/wlan_hdd_assoc.c
@@ -2135,8 +2135,10 @@ QDF_STATUS hdd_roam_register_sta(struct hdd_adapter *adapter,
 		hdd_conn_set_authenticated(adapter, true);
 		hdd_objmgr_set_peer_mlme_auth_state(adapter->vdev, true);
 	} else {
+#ifdef WLAN_DEBUG
 		hdd_debug("ULA auth StaId= %d. Changing TL state to CONNECTED at Join time",
 			 sta_ctx->conn_info.staId[0]);
+#endif
 		qdf_status =
 			hdd_change_peer_state(adapter, staDesc.sta_id,
 						OL_TXRX_PEER_STATE_CONN,

--- a/core/hdd/src/wlan_hdd_cfg.c
+++ b/core/hdd/src/wlan_hdd_cfg.c
@@ -7384,7 +7384,6 @@ static void hdd_cfg_print_action_oui(struct hdd_context *hdd_ctx)
 {
 #ifdef WLAN_DEBUG
 	struct hdd_config *config = hdd_ctx->config;
-#endif
 
 	hdd_debug("Name = [%s] value = [%u]",
 		  CFG_ENABLE_ACTION_OUI,
@@ -7421,6 +7420,7 @@ static void hdd_cfg_print_action_oui(struct hdd_context *hdd_ctx)
 	hdd_debug("Name = [%s] value = [%s]",
 		  CFG_ACTION_OUI_DISABLE_AGGRESSIVE_EDCA,
 		  config->action_oui_str[ACTION_OUI_DISABLE_AGGRESSIVE_EDCA]);
+#endif
 }
 
 /**

--- a/core/hdd/src/wlan_hdd_cfg80211.c
+++ b/core/hdd/src/wlan_hdd_cfg80211.c
@@ -5114,9 +5114,7 @@ static int __wlan_hdd_cfg80211_disable_dfs_chan_scan(struct wiphy *wiphy,
 						     const void *data,
 						     int data_len)
 {
-#ifdef WLAN_DEBUG
 	struct net_device *dev = wdev->netdev;
-#endif
 	struct hdd_context *hdd_ctx  = wiphy_priv(wiphy);
 	struct nlattr *tb[QCA_WLAN_VENDOR_ATTR_SET_NO_DFS_FLAG_MAX + 1];
 	int ret_val;
@@ -21908,18 +21906,18 @@ int wlan_hdd_disconnect(struct hdd_adapter *adapter, u16 reason,
  */
 static void hdd_print_netdev_txq_status(struct net_device *dev)
 {
+#ifdef WLAN_DEBUG
 	unsigned int i;
 
 	if (!dev)
 		return;
 
 	for (i = 0; i < dev->num_tx_queues; i++) {
-#ifdef WLAN_DEBUG
 		struct netdev_queue *txq = netdev_get_tx_queue(dev, i);
-#endif
 
 		hdd_debug("netdev tx queue[%u] state: 0x%lx", i, txq->state);
 	}
+#endif
 }
 
 /**

--- a/core/hdd/src/wlan_hdd_main.c
+++ b/core/hdd/src/wlan_hdd_main.c
@@ -9045,7 +9045,9 @@ static uint8_t *convert_level_to_string(uint32_t level)
  */
 void wlan_hdd_display_tx_rx_histogram(struct hdd_context *hdd_ctx)
 {
+#ifdef WLAN_DEBUG
 	int i;
+#endif
 
 #ifdef MSM_PLATFORM
 	hdd_debug("BW compute Interval: %dms",
@@ -9068,6 +9070,7 @@ void wlan_hdd_display_tx_rx_histogram(struct hdd_context *hdd_ctx)
 
 	hdd_debug("[index][timestamp]: interval_rx, interval_tx, bus_bw_level, RX TP Level, TX TP Level");
 
+#ifdef WLAN_DEBUG
 	for (i = 0; i < NUM_TX_RX_HISTOGRAM; i++) {
 		/* using hdd_log to avoid printing function name */
 		if (hdd_ctx->hdd_txrx_hist[i].qtime > 0)
@@ -9085,6 +9088,7 @@ void wlan_hdd_display_tx_rx_histogram(struct hdd_context *hdd_ctx)
 					hdd_ctx->hdd_txrx_hist[i].
 						next_tx_level));
 	}
+#endif
 }
 
 /**

--- a/core/hdd/src/wlan_hdd_wext.c
+++ b/core/hdd/src/wlan_hdd_wext.c
@@ -3237,11 +3237,10 @@ static QDF_STATUS hdd_wlan_get_ibss_peer_info(struct hdd_adapter *adapter,
 
 		/** Print the peer info */
 		hdd_debug("pPeerInfo->numIBSSPeers = %d ", pPeerInfo->numPeers);
+#ifdef WLAN_DEBUG
 		{
 			uint8_t mac_addr[QDF_MAC_ADDR_SIZE];
-#ifdef WLAN_DEBUG
 			uint32_t tx_rate = pPeerInfo->peerInfoParams[0].txRate;
-#endif
 
 			qdf_mem_copy(mac_addr, pPeerInfo->peerInfoParams[0].
 					mac_addr, sizeof(mac_addr));
@@ -3249,6 +3248,7 @@ static QDF_STATUS hdd_wlan_get_ibss_peer_info(struct hdd_adapter *adapter,
 				mac_addr, (int)tx_rate,
 				(int)pPeerInfo->peerInfoParams[0].rssi);
 		}
+#endif
 	} else {
 		hdd_warn("Warning: sme_request_ibss_peer_info Request failed");
 	}

--- a/core/mac/src/pe/lim/lim_process_tdls.c
+++ b/core/mac/src/pe/lim/lim_process_tdls.c
@@ -657,10 +657,12 @@ static QDF_STATUS lim_send_tdls_dis_req_frame(tpAniSirGlobal pMac,
 	}
 #endif
 
+#ifdef WLAN_DEBUG
 	pe_debug("[TDLS] action: %d (%s) -AP-> OTA peer="MAC_ADDRESS_STR,
 		SIR_MAC_TDLS_DIS_REQ,
 		lim_trace_tdls_action_string(SIR_MAC_TDLS_DIS_REQ),
 		MAC_ADDR_ARRAY(peer_mac.bytes));
+#endif
 
 	pMac->lim.tdls_frm_session_id = psessionEntry->smeSessionId;
 	lim_diag_mgmt_tx_event_report(pMac, (tpSirMacMgmtHdr) pFrame,
@@ -962,11 +964,12 @@ static QDF_STATUS lim_send_tdls_dis_rsp_frame(tpAniSirGlobal pMac,
 		qdf_mem_copy(pFrame + sizeof(tSirMacMgmtHdr) + nPayload, addIe,
 			     addIeLen);
 	}
+#ifdef WLAN_DEBUG
 	pe_debug("[TDLS] action: %d (%s) -DIRECT-> OTA peer="MAC_ADDRESS_STR,
 		SIR_MAC_TDLS_DIS_RSP,
 		lim_trace_tdls_action_string(SIR_MAC_TDLS_DIS_RSP),
 		MAC_ADDR_ARRAY(peer_mac.bytes));
-
+#endif
 	pMac->lim.tdls_frm_session_id = psessionEntry->smeSessionId;
 	lim_diag_mgmt_tx_event_report(pMac, (tpSirMacMgmtHdr) pFrame,
 				      psessionEntry, QDF_STATUS_SUCCESS,
@@ -1337,12 +1340,12 @@ QDF_STATUS lim_send_tdls_link_setup_req_frame(tpAniSirGlobal pMac,
 		qdf_mem_copy(pFrame + header_offset + nPayload, addIe,
 			     addIeLen);
 	}
-
+#ifdef WLAN_DEBUG
 	pe_debug("[TDLS] action: %d (%s) -AP-> OTA peer="MAC_ADDRESS_STR,
 		SIR_MAC_TDLS_SETUP_REQ,
 		lim_trace_tdls_action_string(SIR_MAC_TDLS_SETUP_REQ),
 		MAC_ADDR_ARRAY(peer_mac.bytes));
-
+#endif
 	pMac->lim.tdls_frm_session_id = psessionEntry->smeSessionId;
 	lim_diag_mgmt_tx_event_report(pMac, (tpSirMacMgmtHdr) pFrame,
 				      psessionEntry, QDF_STATUS_SUCCESS,
@@ -1529,13 +1532,14 @@ QDF_STATUS lim_send_tdls_teardown_frame(tpAniSirGlobal pMac,
 				    padLen - MIN_VENDOR_SPECIFIC_IE_SIZE);
 	}
 #endif
+#ifdef WLAN_DEBUG
 	pe_debug("[TDLS] action: %d (%s) -%s-> OTA peer="MAC_ADDRESS_STR,
 		SIR_MAC_TDLS_TEARDOWN,
 		lim_trace_tdls_action_string(SIR_MAC_TDLS_TEARDOWN),
 		((reason == eSIR_MAC_TDLS_TEARDOWN_PEER_UNREACHABLE) ? "AP" :
 		    "DIRECT"),
 		MAC_ADDR_ARRAY(peer_mac.bytes));
-
+#endif
 	pMac->lim.tdls_frm_session_id = psessionEntry->smeSessionId;
 	lim_diag_mgmt_tx_event_report(pMac, (tpSirMacMgmtHdr) pFrame,
 				      psessionEntry, QDF_STATUS_SUCCESS,
@@ -1792,12 +1796,12 @@ static QDF_STATUS lim_send_tdls_setup_rsp_frame(tpAniSirGlobal pMac,
 		qdf_mem_copy(pFrame + header_offset + nPayload, addIe,
 			     addIeLen);
 	}
-
+#ifdef WLAN_DEBUG
 	pe_debug("[TDLS] action: %d (%s) -AP-> OTA peer="MAC_ADDRESS_STR,
 		SIR_MAC_TDLS_SETUP_RSP,
 		lim_trace_tdls_action_string(SIR_MAC_TDLS_SETUP_RSP),
 		MAC_ADDR_ARRAY(peer_mac.bytes));
-
+#endif
 	pMac->lim.tdls_frm_session_id = psessionEntry->smeSessionId;
 	lim_diag_mgmt_tx_event_report(pMac, (tpSirMacMgmtHdr) pFrame,
 				      psessionEntry, QDF_STATUS_SUCCESS,
@@ -1999,12 +2003,12 @@ QDF_STATUS lim_send_tdls_link_setup_cnf_frame(tpAniSirGlobal pMac,
 				    padLen - MIN_VENDOR_SPECIFIC_IE_SIZE);
 	}
 #endif
-
+#ifdef WLAN_DEBUG
 	pe_debug("[TDLS] action: %d (%s) -AP-> OTA peer="MAC_ADDRESS_STR,
 		SIR_MAC_TDLS_SETUP_CNF,
 		lim_trace_tdls_action_string(SIR_MAC_TDLS_SETUP_CNF),
 	       MAC_ADDR_ARRAY(peer_mac.bytes));
-
+#endif
 	pMac->lim.tdls_frm_session_id = psessionEntry->smeSessionId;
 	lim_diag_mgmt_tx_event_report(pMac, (tpSirMacMgmtHdr) pFrame,
 				      psessionEntry, QDF_STATUS_SUCCESS,

--- a/core/mac/src/pe/lim/lim_send_management_frames.c
+++ b/core/mac/src/pe/lim/lim_send_management_frames.c
@@ -5170,9 +5170,10 @@ void lim_send_mgmt_frame_tx(tpAniSirGlobal mac_ctx,
 	void *packet;
 
 	msg_len = mb_msg->msg_len - sizeof(*mb_msg);
+#ifdef WLAN_DEBUG
 	pe_debug("sending fc->type: %d fc->subType: %d",
 		fc->type, fc->subType);
-
+#endif
 	sme_session_id = mb_msg->session_id;
 
 	qdf_status = cds_packet_alloc((uint16_t) msg_len, (void **)&frame,

--- a/core/sap/src/sap_fsm.c
+++ b/core/sap/src/sap_fsm.c
@@ -2740,7 +2740,9 @@ QDF_STATUS sap_fsm(struct sap_context *sap_ctx, ptWLAN_SAPEvent sap_event)
 
 	mac_ctx = PMAC_STRUCT(hal);
 
+#ifdef WLAN_DEBUG
 	sap_debug("state=%d handle event=%d", state_var, msg);
+#endif
 
 	switch (state_var) {
 	case SAP_INIT:

--- a/core/sap/src/sap_module.c
+++ b/core/sap/src/sap_module.c
@@ -1316,12 +1316,14 @@ QDF_STATUS wlansap_set_channel_change_with_csa(struct sap_context *sapContext,
 		sap_err("%u is unsafe channel", targetChannel);
 		return QDF_STATUS_E_FAULT;
 	}
+#ifdef WLAN_DEBUG
 	sap_nofl_debug("SAP CSA: %d ---> %d conn on 5GHz:%d, csa_reason:%s(%d) strict %d vdev %d",
 		       sapContext->channel, targetChannel,
 		       policy_mgr_is_any_mode_active_on_band_along_with_session(
 		       pMac->psoc, sapContext->sessionId, POLICY_MGR_BAND_5),
 		       sap_get_csa_reason_str(sapContext->csa_reason),
 		       sapContext->csa_reason, strict, sapContext->sessionId);
+#endif
 
 	sta_sap_scc_on_dfs_chan =
 		policy_mgr_is_sta_sap_scc_allowed_on_dfs_chan(pMac->psoc);

--- a/core/sme/src/common/sme_api.c
+++ b/core/sme/src/common/sme_api.c
@@ -6026,8 +6026,10 @@ void sme_set_cc_src(tHalHandle hHal, enum country_src cc_src)
 
 	mac_ctx->reg_hint_src = cc_src;
 
+#ifdef WLAN_DEBUG
 	sme_debug("Country source is %s",
 		  sme_reg_hint_to_str(cc_src));
+#endif
 }
 
 /**

--- a/core/sme/src/csr/csr_api_roam.c
+++ b/core/sme/src/csr/csr_api_roam.c
@@ -4504,7 +4504,9 @@ static const char *csr_get_encr_type_str(uint8_t encr_type)
 	}
 }
 #endif
+#endif
 
+#if defined(WLAN_DEBUG) && defined(FEATURE_WLAN_DIAG_SUPPORT_CSR)
 static void csr_dump_connection_stats(tpAniSirGlobal mac_ctx,
 		struct csr_roam_session *session,
 		struct csr_roam_info *roam_info,
@@ -14112,6 +14114,7 @@ static QDF_STATUS csr_roam_start_wait_for_key_timer(
 	if (csr_neighbor_roam_is_handoff_in_progress(pMac,
 				     pMac->roam.WaitForKeyTimerInfo.
 				     vdev_id)) {
+#ifdef WLAN_DEBUG
 		/* Disable heartbeat timer when hand-off is in progress */
 		sme_debug("disabling HB timer in state: %s sub-state: %s",
 			mac_trace_get_neighbour_roam_state(
@@ -14119,6 +14122,7 @@ static QDF_STATUS csr_roam_start_wait_for_key_timer(
 			mac_trace_getcsr_roam_sub_state(
 				pMac->roam.curSubState[pMac->roam.
 					WaitForKeyTimerInfo.vdev_id]));
+#endif
 		cfg_set_int(pMac, WNI_CFG_HEART_BEAT_THRESHOLD, 0);
 	}
 	sme_debug("csrScanStartWaitForKeyTimer");
@@ -14134,7 +14138,6 @@ QDF_STATUS csr_roam_stop_wait_for_key_timer(tpAniSirGlobal pMac)
 	tpCsrNeighborRoamControlInfo pNeighborRoamInfo =
 		&pMac->roam.neighborRoamInfo[pMac->roam.WaitForKeyTimerInfo.
 					     vdev_id];
-#endif
 
 	sme_debug("WaitForKey timer stopped in state: %s sub-state: %s",
 		mac_trace_get_neighbour_roam_state(pNeighborRoamInfo->
@@ -14143,6 +14146,7 @@ QDF_STATUS csr_roam_stop_wait_for_key_timer(tpAniSirGlobal pMac)
 						curSubState[pMac->roam.
 							    WaitForKeyTimerInfo.
 							    vdev_id]));
+#endif
 	if (csr_neighbor_roam_is_handoff_in_progress(pMac,
 				pMac->roam.WaitForKeyTimerInfo.vdev_id)) {
 		/*

--- a/core/sme/src/csr/csr_neighbor_roam.c
+++ b/core/sme/src/csr/csr_neighbor_roam.c
@@ -228,8 +228,10 @@ QDF_STATUS csr_neighbor_roam_update_config(tpAniSirGlobal mac_ctx,
 		csr_roam_offload_scan(mac_ctx, session_id,
 			ROAM_SCAN_OFFLOAD_UPDATE_CFG, reason);
 	}
+#ifdef WLAN_DEBUG
 	sme_debug("LFR config for %s changed from %d to %d",
 			lfr_get_config_item_string(reason), old_value, value);
+#endif
 	return QDF_STATUS_SUCCESS;
 }
 

--- a/core/wma/src/wma_mgmt.c
+++ b/core/wma/src/wma_mgmt.c
@@ -3181,10 +3181,10 @@ static int wma_process_mgmt_tx_completion(tp_wma_handle wma_handle,
 		WMA_LOGE("%s: wma handle is NULL", __func__);
 		return -EINVAL;
 	}
-
+#ifdef WLAN_DEBUG
 	wma_debug("status: %s wmi_desc_id: %d",
 		  wma_get_status_str(status), desc_id);
-
+#endif
 	pdev = wma_handle->pdev;
 	if (pdev == NULL) {
 		WMA_LOGE("%s: psoc ptr is NULL", __func__);


### PR DESCRIPTION
This patchset fixes the driver to be compiled without heavy debugging
and reduces memory footprint by disabling packet logging.

....Ah, and it also disables debugging :)))