### PR TITLE
[QCACLD] [8.1.r1] Fix Kumano compilation error on buffer read overflow

### DIFF
--- a/core/mac/src/pe/lim/lim_process_fils.c
+++ b/core/mac/src/pe/lim/lim_process_fils.c
@@ -886,6 +886,7 @@ static QDF_STATUS lim_process_auth_wrapped_data(tpPESession pe_session,
 	} else {
 		pe_err("invalid remaining len %d",
 			remaining_len);
+		return QDF_STATUS_E_FAILURE;
 	}
 	if (qdf_mem_cmp(wrapped_data, hash, auth_tag_len)) {
 		pe_err("integratity check failed for auth, crypto %d",


### PR DESCRIPTION
Without this return the compiler is detecting a possible read overflow:

    In function ‘memcmp’,
        inlined from ‘__qdf_mem_cmp’ at drivers/staging/wlan-qc/qcacld-3.0/../qca-wifi-host-cmn/qdf/linux/src/i_qdf_mem.h:201:9,
        inlined from ‘qdf_mem_cmp’ at drivers/staging/wlan-qc/qcacld-3.0/../qca-wifi-host-cmn/qdf/inc/qdf_mem.h:260:9,
        inlined from ‘lim_process_auth_wrapped_data’ at drivers/staging/wlan-qc/qcacld-3.0/core/mac/src/pe/lim/lim_process_fils.c:890:6:
      CC      drivers/staging/wlan-qc/qcacld-3.0/../qca-wifi-host-cmn/qdf/linux/src/qdf_nbuf.o
    include/linux/string.h:435:4: error: call to ‘__read_overflow2’ declared with attribute error: detected read beyond size of object passed as 2nd parameter
        __read_overflow2();
        ^~~~~~~~~~~~~~~~~~
