### PR TITLE
[QCACLD] [8.1.r1] Enable SMMU S1 Translation on MSM8998/SDM630/660

### DIFF
--- a/configs/default_defconfig
+++ b/configs/default_defconfig
@@ -498,14 +498,22 @@ CONFIG_ENABLE_SMMU_S1_TRANSLATION := y
 endif
 endif
 
-ifeq ($(CONFIG_HELIUMPLUS), y)
-ifneq ($(CONFIG_ARCH_SDM630), y)
-ifneq ($(CONFIG_ARCH_SDM660), y)
-ifneq ($(CONFIG_ARCH_MSM8998), y)
+ifeq ($(CONFIG_ARCH_SDM630), y)
 ifeq ($(CONFIG_IPA_OFFLOAD), y)
 CONFIG_ENABLE_SMMU_S1_TRANSLATION := y
 endif
 endif
+
+ifeq ($(CONFIG_ARCH_SDM660), y)
+ifeq ($(CONFIG_IPA_OFFLOAD), y)
+CONFIG_ENABLE_SMMU_S1_TRANSLATION := y
+endif
+endif
+
+ifeq ($(CONFIG_HELIUMPLUS), y)
+ifneq ($(CONFIG_ARCH_MSM8998), y)
+ifeq ($(CONFIG_IPA_OFFLOAD), y)
+CONFIG_ENABLE_SMMU_S1_TRANSLATION := y
 endif
 endif
 endif

--- a/configs/default_defconfig
+++ b/configs/default_defconfig
@@ -510,11 +510,9 @@ CONFIG_ENABLE_SMMU_S1_TRANSLATION := y
 endif
 endif
 
-ifeq ($(CONFIG_HELIUMPLUS), y)
-ifneq ($(CONFIG_ARCH_MSM8998), y)
+ifeq ($(CONFIG_ARCH_MSM8998), y)
 ifeq ($(CONFIG_IPA_OFFLOAD), y)
 CONFIG_ENABLE_SMMU_S1_TRANSLATION := y
-endif
 endif
 endif
 

--- a/core/dp/txrx/ol_tx_queue.c
+++ b/core/dp/txrx/ol_tx_queue.c
@@ -1754,7 +1754,7 @@ void ol_txrx_vdev_unpause(struct cdp_vdev *pvdev, uint32_t reason)
 			vdev->ll_pause.is_q_paused = false;
 			vdev->ll_pause.q_unpause_cnt++;
 			qdf_spin_unlock_bh(&vdev->ll_pause.mutex);
-			ol_tx_vdev_ll_pause_queue_send((unsigned long) vdev);
+			ol_tx_vdev_ll_pause_queue_send(vdev);
 		} else {
 			qdf_spin_unlock_bh(&vdev->ll_pause.mutex);
 		}


### PR DESCRIPTION
After my fixes on the IPAv2 driver, we were able to enable the
IOMMU context for IPA<->ICNSS communication in the kernel!

Let's unleash the beast here has well.

P.S.: Another fix also sneaked in too! :P