### PR TITLE
[LA.UM.8.1.r1] qcacld-3.0: Initialize sessionId in csr_roam_joined_state_msg_processor

### DIFF
--- a/core/sme/src/csr/csr_api_roam.c
+++ b/core/sme/src/csr/csr_api_roam.c
@@ -11518,7 +11518,7 @@ void csr_roam_joined_state_msg_processor(tpAniSirGlobal pMac, void *pMsgBuf)
 		struct csr_roam_session *pSession;
 		tSirSmeAssocIndToUpperLayerCnf *pUpperLayerAssocCnf;
 		struct csr_roam_info *roam_info;
-		uint32_t sessionId;
+		uint32_t sessionId = CSR_SESSION_ID_INVALID;
 		QDF_STATUS status;
 
 		sme_debug("ASSOCIATION confirmation can be given to upper layer ");


### PR DESCRIPTION
Use the same value as used elsewhere in the file when used as
paramenter of csr_roam_get_session_id_from_bssid().

Signed-off-by: Pablo Mendez Hernandez <pablomh@gmail.com>